### PR TITLE
Result API changes

### DIFF
--- a/packages/node-stdlib/src/core/result.ts
+++ b/packages/node-stdlib/src/core/result.ts
@@ -69,11 +69,6 @@ interface ResultCase<S, F> {
   failure(): F | undefined;
 
   /**
-   * Returns the success value or `defaultValue` if the result is a `Failure`.
-   */
-  orElse(defaultValue: S): S;
-
-  /**
    * Returns a new result, mapping the `Success` value using the given `transform` closure.
    */
   map<T>(transform: (value: S) => T): Result<T, F>;
@@ -96,12 +91,6 @@ interface ResultCase<S, F> {
   flatMapFailure<E>(transform: (err: F) => Result<S, E>): Result<S, E>;
 
   /**
-   * Returns the result of calling `onSuccess` if the result is a `Success`
-   * or `onFailure` if the result is a `Failure`.
-   */
-  fold<T>(onSuccess: (value: S) => T, onFailure: (err: F) => T): T;
-
-  /**
    * Custom inspect implementation for use with node's `util.inspect`.
    */
   [inspect.custom](depth?: number | null, options?: InspectOptions): string;
@@ -122,7 +111,7 @@ class Success<S, F> implements ResultCase<S, F> {
     return false;
   }
 
-  unwrap(msg?: string): S {
+  unwrap(_msg?: string): S {
     return this.#value;
   }
 
@@ -142,15 +131,11 @@ class Success<S, F> implements ResultCase<S, F> {
     return undefined;
   }
 
-  orElse(defaultValue: S): S {
-    return this.#value;
-  }
-
   map<T>(transform: (value: S) => T): Result<T, F> {
     return new Success(transform(this.#value));
   }
 
-  mapFailure<E>(transform: (err: F) => E): Result<S, E> {
+  mapFailure<E>(_transform: (err: F) => E): Result<S, E> {
     return new Success(this.#value);
   }
 
@@ -158,12 +143,8 @@ class Success<S, F> implements ResultCase<S, F> {
     return transform(this.#value);
   }
 
-  flatMapFailure<E>(transform: (err: F) => Result<S, E>): Result<S, E> {
+  flatMapFailure<E>(_transform: (err: F) => Result<S, E>): Result<S, E> {
     return new Success(this.#value);
-  }
-
-  fold<T>(onSuccess: (value: S) => T, onFailure: (err: F) => T): T {
-    return onSuccess(this.#value);
   }
 
   [inspect.custom](depth?: number | null, options?: InspectOptions): string {
@@ -204,7 +185,7 @@ class Failure<S, F> implements ResultCase<S, F> {
     panic(`${msg}: ${toString(this.#cause)}`);
   }
 
-  unwrapFailure(msg?: string): F {
+  unwrapFailure(_msg?: string): F {
     return this.#cause;
   }
 
@@ -216,11 +197,7 @@ class Failure<S, F> implements ResultCase<S, F> {
     return this.#cause;
   }
 
-  orElse(defaultValue: S): S {
-    return defaultValue;
-  }
-
-  map<T>(transform: (value: S) => T): Result<T, F> {
+  map<T>(_transform: (value: S) => T): Result<T, F> {
     return new Failure(this.#cause);
   }
 
@@ -228,16 +205,12 @@ class Failure<S, F> implements ResultCase<S, F> {
     return new Failure(transform(this.#cause));
   }
 
-  flatMap<T>(transform: (value: S) => Result<T, F>): Result<T, F> {
+  flatMap<T>(_transform: (value: S) => Result<T, F>): Result<T, F> {
     return new Failure(this.#cause);
   }
 
   flatMapFailure<E>(transform: (err: F) => Result<S, E>): Result<S, E> {
     return transform(this.#cause);
-  }
-
-  fold<T>(onSuccess: (value: S) => T, onFailure: (err: F) => T): T {
-    return onFailure(this.#cause);
   }
 
   [inspect.custom](depth?: number | null, options?: InspectOptions): string {

--- a/packages/node-stdlib/test/core/result.test.ts
+++ b/packages/node-stdlib/test/core/result.test.ts
@@ -19,14 +19,28 @@ describe("Result", () => {
       const r = Result.of(() => {
         return 2;
       });
-      expect(r.isSuccess()).toBe(true);
+      expect(r).toBeSuccess();
     });
 
     it("converts a throwing function to a Failure", () => {
       const r = Result.of(() => {
         throw new Error("Oh no!");
       });
-      expect(r.isFailure()).toBe(true);
+      expect(r).toBeFailure();
+    });
+
+    it("converts a throwing async function to a Success", async () => {
+      const r = await Result.ofPromise(async () => {
+        return 2;
+      });
+      expect(r).toBeSuccess();
+    });
+
+    it("converts a throwing async function to a Failure", async () => {
+      const r = await Result.ofPromise(async () => {
+        throw new Error("Oh no!");
+      });
+      expect(r).toBeFailure();
     });
   });
 

--- a/packages/node-stdlib/test/core/result.test.ts
+++ b/packages/node-stdlib/test/core/result.test.ts
@@ -110,18 +110,6 @@ describe("Result", () => {
     });
   });
 
-  describe("orElse()", () => {
-    it("returns the value when the result a Success", () => {
-      const r = Result.success(10);
-      expect(r.orElse(2)).toBe(10);
-    });
-
-    it("returns the default value when the result is Failure", () => {
-      const r = Result.failure("Oh no!");
-      expect(r.orElse(2)).toBe(2);
-    });
-  });
-
   describe("map()", () => {
     it("creates a new result mapping the success value", () => {
       const r = Result.success(10);
@@ -187,26 +175,6 @@ describe("Result", () => {
       const newR = r.flatMapFailure((e) => Result.failure(errors.newError(e)));
       expect(newR).not.toBe(r);
       expect(newR.failure()?.error()).toBe(err);
-    });
-  });
-
-  describe("fold()", () => {
-    it("returns the result of onSuccess when the result is a Success", () => {
-      const r = Result.success(10);
-      const val = r.fold(
-        (s) => s + 10,
-        (_e) => 100,
-      );
-      expect(val).toBe(20);
-    });
-
-    it("returns the result of onFailure when the result is a Failure", () => {
-      const r = Result.failure<number, string>("Oh no!");
-      const val = r.fold(
-        (s) => s + 10,
-        (_e) => 100,
-      );
-      expect(val).toBe(100);
     });
   });
 


### PR DESCRIPTION
* Removed `orElse` and `fold` methods of `Result`.
* Added `Result.ofPromise` which is like `Result.of` but handles promises.
* `Result.of`'s failure type is always `Error`, it is no longer a generic parameter.