### PR TITLE
feat!(node-stdlib): Change DynamicBuffer implementation

### DIFF
--- a/packages/node-stdlib/src/log/formatter.ts
+++ b/packages/node-stdlib/src/log/formatter.ts
@@ -26,7 +26,7 @@ export enum FieldKey {
  * Represents a type that can format logs.
  */
 export interface Formatter {
-  format(log: Log): Result<Buffer, error>;
+  format(log: Log): Result<Uint8Array, error>;
 }
 
 function resolveKey(key: string, f: Map<string, string>): string {
@@ -87,7 +87,7 @@ export class JSONFormatter implements Formatter {
     this.fieldMap = opts?.fieldMap ?? new Map();
   }
 
-  format(log: Log): Result<Buffer, error> {
+  format(log: Log): Result<Uint8Array, error> {
     let data: Fields = {};
     for (const [k, v] of Object.entries(log.data)) {
       // Handle errors specially so they get stringified properly
@@ -120,7 +120,7 @@ export class JSONFormatter implements Formatter {
 
     const indent = this.prettyPrint ? 2 : undefined;
     return Result.of(() => JSON.stringify(data, null, indent))
-      .map((json) => Buffer.from(json))
+      .map((json) => new TextEncoder().encode(json))
       .mapFailure((err) => errors.fromJSError(err));
   }
 }
@@ -301,7 +301,7 @@ export class TextFormatter implements Formatter {
     }
   };
 
-  format(log: Log): Result<Buffer, error> {
+  format(log: Log): Result<Uint8Array, error> {
     const data = { ...log.data };
     prefixFieldClashes(data, this.fieldMap);
 

--- a/packages/node-stdlib/src/log/log.ts
+++ b/packages/node-stdlib/src/log/log.ts
@@ -54,7 +54,7 @@ export interface Logger {
  * Generally implemented by a Stream or Buffer.
  */
 export interface Writable {
-  write(buffer: Buffer | Uint8Array): void;
+  write(buffer: Uint8Array): void;
 }
 
 /**

--- a/packages/node-stdlib/test/log/formatter.test.ts
+++ b/packages/node-stdlib/test/log/formatter.test.ts
@@ -12,6 +12,10 @@ function createLogFixture(l?: Partial<log.Log>): log.Log {
   };
 }
 
+function bufToString(buf: Uint8Array): string {
+  return new TextDecoder("utf-8").decode(buf);
+}
+
 describe("log/formatter.ts", () => {
   describe("JSONFormatter", () => {
     it("formats the log as json", () => {
@@ -19,7 +23,7 @@ describe("log/formatter.ts", () => {
         data: { foo: "bar" },
       });
       const f = new log.JSONFormatter();
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
       const json = JSON.parse(s);
 
       expect(json).toEqual({
@@ -39,7 +43,7 @@ describe("log/formatter.ts", () => {
         },
       });
       const f = new log.JSONFormatter();
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
       const json = JSON.parse(s);
 
       expect(json).toEqual({
@@ -67,7 +71,7 @@ describe("log/formatter.ts", () => {
           [log.FieldKey.msg, "@msg"],
         ]),
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
       const json = JSON.parse(s);
 
       expect(json).toEqual({
@@ -88,7 +92,7 @@ describe("log/formatter.ts", () => {
         },
       });
       const f = new log.JSONFormatter();
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
       const json = JSON.parse(s);
 
       expect(json).toEqual({
@@ -110,7 +114,7 @@ describe("log/formatter.ts", () => {
       const f = new log.JSONFormatter({
         dataKey: "props",
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
       const json = JSON.parse(s);
 
       expect(json).toEqual({
@@ -131,7 +135,7 @@ describe("log/formatter.ts", () => {
         data: { foo: "bar" },
       });
       const f = new log.TextFormatter();
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       const regex = new RegExp(`time="${isoRegex}" level=debug msg="log message" foo=bar`);
       expect(s).toMatch(regex);
@@ -146,7 +150,7 @@ describe("log/formatter.ts", () => {
         },
       });
       const f = new log.TextFormatter();
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       const regex = new RegExp(
         `time="${isoRegex}" level=debug msg="log message" fields.level=56 fields.msg="some stuff" fields.time=noon`,
@@ -169,7 +173,7 @@ describe("log/formatter.ts", () => {
           [log.FieldKey.msg, "@msg"],
         ]),
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       const regex = new RegExp(
         `@time="${isoRegex}" @level=debug @msg="log message" level=56 msg="some stuff" time=noon`,
@@ -184,7 +188,7 @@ describe("log/formatter.ts", () => {
       const f = new log.TextFormatter({
         forceQuote: true,
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       const regex = new RegExp(`time="${isoRegex}" level="debug" msg="log message" foo="bar"`);
       expect(s).toMatch(regex);
@@ -197,7 +201,7 @@ describe("log/formatter.ts", () => {
       const f = new log.TextFormatter({
         disableQuote: true,
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       const regex = new RegExp(`time=${isoRegex} level=debug msg=log message foo=bar`);
       expect(s).toMatch(regex);
@@ -211,7 +215,7 @@ describe("log/formatter.ts", () => {
         forceColors: true,
         disableTimestamp: true,
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       expect(s).toBe(`${colors.white("DEBU")} log message ${colors.white("foo")}=bar\n`);
     });
@@ -226,7 +230,7 @@ describe("log/formatter.ts", () => {
         disableTimestamp: true,
         disableLevelTruncation: true,
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       expect(s).toBe(`${colors.red("ERROR")} log message ${colors.red("foo")}=bar\n`);
     });
@@ -241,7 +245,7 @@ describe("log/formatter.ts", () => {
         disableTimestamp: true,
         padLevelText: true,
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       expect(s).toBe(`${colors.blue("INFO ")} log message ${colors.blue("foo")}=bar\n`);
     });
@@ -263,7 +267,7 @@ describe("log/formatter.ts", () => {
         disableColors: true,
         disableTimestamp: true,
       });
-      const s = f.format(l).unwrap().toString();
+      const s = bufToString(f.format(l).unwrap());
 
       const e = `level=debug msg="log message" bool=true error="oh no" nil=null num=10.5 obj="{ a: 1, b: 'prop' }" semver=1.12.5 str=hello undef=undefined\n`;
       expect(s).toBe(e);


### PR DESCRIPTION
Change usages of Node's `Buffer` to `Uint8Array`. The biggest of these changes is with regards to `DynamicBuffer`.

`DynamicBuffer` now uses a `Uint8Array` under the hood instead of a `Buffer`. As a consequence this is a breaking change because only `utf8` encoded strings are supported now. The motivation behind this is to not have any of the modified modules be coupled to Node. That way they could be potentially ported to the browser or Deno.