### PR TITLE
feat(node-stdlib): Simplify inspect usages

### DIFF
--- a/packages/node-stdlib/src/bytes/dynamic_buffer.ts
+++ b/packages/node-stdlib/src/bytes/dynamic_buffer.ts
@@ -8,7 +8,6 @@
 import { inspect } from "util";
 import { Result, panic, symbols } from "../global";
 import * as errors from "../errors/mod";
-import * as hex from "../hex/mod";
 import { copy } from "./bytes";
 
 // Node limit for the size of ArrayBuffers
@@ -380,25 +379,7 @@ export class DynamicBuffer implements Iterable<number> {
   /**
    * Custom inspect implementation for use with node's `util.inspect`.
    */
-  [inspect.custom](depth?: number | null): string {
-    if (depth == null || depth < 0) {
-      return "DynamicBuffer {}";
-    }
-
-    // Limit to a max of 50 bytes to display
-    const max = 50;
-    const actualMax = Math.min(max, this.length);
-    const remaining = this.length - max;
-
-    let bytes = hex
-      .encodeToString(this.#buf.subarray(this.#off, actualMax + this.#off))
-      .replace(/(.{2})/g, "$1 ")
-      .trim();
-
-    if (remaining > 0) {
-      bytes += ` ... ${remaining} more byte${remaining > 1 ? "s" : ""}`;
-    }
-
-    return `DynamicBuffer { ${bytes} }`;
+  [inspect.custom](): string {
+    return `DynamicBuffer(${this.length})`;
   }
 }

--- a/packages/node-stdlib/src/util/semver.ts
+++ b/packages/node-stdlib/src/util/semver.ts
@@ -111,12 +111,8 @@ export class SemVer {
   /**
    * Custom inspect implementation for use with node's `util.inspect`.
    */
-  [inspect.custom](depth?: number | null): string {
-    if (depth == null || depth < 0) {
-      return "SemVer {}";
-    }
-
-    return `SemVer { ${this.toString()} }`;
+  [inspect.custom](): string {
+    return `SemVer(${this.toString()})`;
   }
 
   /**

--- a/packages/node-stdlib/src/uuid/uuid.ts
+++ b/packages/node-stdlib/src/uuid/uuid.ts
@@ -122,12 +122,8 @@ class UUID {
   /**
    * Custom inspect implementation for use with node's `util.inspect`.
    */
-  [inspect.custom](depth?: number | null): string {
-    if (depth == null || depth < 0) {
-      return "UUID {}";
-    }
-
-    return `UUID { ${this.toString()} }`;
+  [inspect.custom](): string {
+    return `UUID(${this.toString()})`;
   }
 }
 

--- a/packages/node-stdlib/test/bytes/dynamic_buffer.test.ts
+++ b/packages/node-stdlib/test/bytes/dynamic_buffer.test.ts
@@ -264,18 +264,11 @@ describe("bytes/dynamic_buffer.ts", () => {
   });
 
   describe("inspect", () => {
-    it("returns just the type when depth is zero", () => {
-      const src = hex.decodeString("10ffab23ef5d").unwrap();
-      const buf = new bytes.DynamicBuffer(src);
-      const s = inspect(buf, { depth: -1 });
-      expect(s).toBe("DynamicBuffer {}");
-    });
-
-    it("returns a string representation of the box", () => {
+    it("returns the name of the class and the buffer length", () => {
       const src = hex.decodeString("10ffab23ef5d").unwrap();
       const buf = new bytes.DynamicBuffer(src);
       const s = inspect(buf);
-      expect(s).toBe("DynamicBuffer { 10 ff ab 23 ef 5d }");
+      expect(s).toBe("DynamicBuffer(6)");
     });
   });
 });

--- a/packages/node-stdlib/test/global.test.ts
+++ b/packages/node-stdlib/test/global.test.ts
@@ -64,16 +64,10 @@ describe("global.ts", () => {
     });
 
     describe("inspect", () => {
-      it("returns just the type when depth is zero", () => {
-        const ref = new Ref(10);
-        const s = inspect(ref, { depth: -1 });
-        expect(s).toBe("Ref {}");
-      });
-
       it("returns a string representation of the ref", () => {
         const ref = new Ref(10);
         const s = inspect(ref);
-        expect(s).toBe("Ref { 10 }");
+        expect(s).toBe("Ref(10)");
       });
     });
   });
@@ -308,22 +302,19 @@ describe("global.ts", () => {
     });
 
     describe("inspect", () => {
-      it("returns just the type when depth is zero", () => {
-        const success = Result.success(10);
-        const failure = Result.failure("oh no!");
-        const s1 = inspect(success, { depth: -1 });
-        const s2 = inspect(failure, { depth: -1 });
-        expect(s1).toBe("Result.success {}");
-        expect(s2).toBe("Result.failure {}");
-      });
-
-      it("returns a string representation of the box", () => {
+      it("returns a string representation of the Result", () => {
         const success = Result.success(10);
         const failure = Result.failure("oh no!");
         const s1 = inspect(success);
         const s2 = inspect(failure);
-        expect(s1).toBe("Result.success { 10 }");
-        expect(s2).toBe("Result.failure { 'oh no!' }");
+        expect(s1).toBe("Result.success(10)");
+        expect(s2).toBe("Result.failure(oh no!)");
+      });
+
+      it("handles errors specially", () => {
+        const failure = Result.failure(errors.errorString("err something blew up"));
+        const s = inspect(failure);
+        expect(s).toBe("Result.failure(err something blew up)");
       });
     });
   });

--- a/packages/node-stdlib/test/util/semver.test.ts
+++ b/packages/node-stdlib/test/util/semver.test.ts
@@ -122,16 +122,10 @@ describe("util/semver.ts", () => {
   });
 
   describe("inspect", () => {
-    it("returns just the type when depth is zero", () => {
-      const sv = new util.SemVer(1, 5, 12);
-      const s = inspect(sv, { depth: -1 });
-      expect(s).toBe("SemVer {}");
-    });
-
-    it("returns a string representation of the box", () => {
+    it("returns a string representation of the semver", () => {
       const sv = new util.SemVer(1, 5, 12);
       const s = inspect(sv);
-      expect(s).toBe("SemVer { 1.5.12 }");
+      expect(s).toBe("SemVer(1.5.12)");
     });
   });
 });

--- a/packages/node-stdlib/test/uuid/uuid.test.ts
+++ b/packages/node-stdlib/test/uuid/uuid.test.ts
@@ -107,18 +107,11 @@ describe("uuid/uuid.ts", () => {
     });
 
     describe("inspect", () => {
-      it("returns just the type when depth is zero", () => {
-        const uuidString = "1d4f6d02-1146-48a8-b0ad-f562220303de";
-        const u = uuid.mustFromString(uuidString);
-        const s = inspect(u, { depth: -1 });
-        expect(s).toBe("UUID {}");
-      });
-
       it("returns a string representation of the UUID", () => {
         const uuidString = "1d4f6d02-1146-48a8-b0ad-f562220303de";
         const u = uuid.mustFromString(uuidString);
         const s = inspect(u);
-        expect(s).toBe("UUID { 1d4f6d02-1146-48a8-b0ad-f562220303de }");
+        expect(s).toBe("UUID(1d4f6d02-1146-48a8-b0ad-f562220303de)");
       });
     });
   });


### PR DESCRIPTION
Custom inspect methods no longer have parameters. This is to make interop with deno possible since deno's custom inspect methods cannot have parameters.